### PR TITLE
UTF Encoding Fix for Annotation Comments

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mgmeyers/pdfannots2json/pdfutils"
 	"github.com/mgmeyers/unipdf/v3/extractor"
 	"github.com/mgmeyers/unipdf/v3/model"
+	"github.com/mgmeyers/unipdf/v3/core"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -364,7 +365,7 @@ func processAnnotations(
 			comment := ""
 
 			if annotation.Contents != nil {
-				comment = pdfutils.RemoveNul(annotation.Contents.String())
+				comment = pdfutils.RemoveNul(core.MakeString(annotation.Contents.String()).String())
 			}
 
 			annotatedText := str

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const version = "v1.0.15"
+const version = "v1.0.16"
 
 var args struct {
 	Version      kong.VersionFlag `short:"v" help:"Display the current version of pdfannots2json"`


### PR DESCRIPTION
Hello,

I encountered an issue when using Cyrillic characters in annotations: during export, the text was transformed into an unreadable set of characters. My knowledge of PDF is not sufficient to confidently pinpoint the exact cause of the problem. However, some code experiments helped me find a simple solution that appears to resolve the issue.

I will illustrate the problem with a specially created PDF file with annotations: [Example.pdf](https://github.com/mgmeyers/pdfannots2json/files/13074982/Example.pdf). For maximum clarity, I will also provide screenshot
![image](https://github.com/mgmeyers/pdfannots2json/assets/1499744/b2afaedb-a8e9-4e4b-bbbe-eb86fd129504)
So, the screenshot shows a PDF with 2 lines of text and 2 annotated annotations in which Latin characters are combined with Cyrillic.

The export of this document looks as follows:
```json
  [
    {
        "annotatedText": "text",
        "color": "#ffff00",
        "colorCategory": "Yellow",
        "comment": "This is :\u003e\u003c\u003c5=B0@89",
        "date": "2023-10-23T20:33:08+03:00",
        "id": "highlight-p1x90y719",
        "page": 1,
        "pageLabel": "1",
        "type": "highlight",
        "x": 90.67,
        "y": 719.27
    },
    {
        "annotatedText": "текст",
        "color": "#00ff00",
        "colorCategory": "Green",
        "comment": "-B\u003e a comment",
        "date": "2023-10-23T20:33:35+03:00",
        "id": "highlight-p1x90y696",
        "page": 1,
        "pageLabel": "1",
        "type": "highlight",
        "x": 90.67,
        "y": 696.66
    }
]
```

As you can see, the "comment" fields contain unreadable characters (where Unicode can be guessed).

The updated version produces results with correctly encoded characters:
```json
[
    {
        "annotatedText": "text",
        "color": "#ffff00",
        "colorCategory": "Yellow",
        "comment": "This is комментарий",
        "date": "2023-10-23T20:33:08+03:00",
        "id": "highlight-p1x90y719",
        "page": 1,
        "pageLabel": "1",
        "type": "highlight",
        "x": 90.67,
        "y": 719.27
    },
    {
        "annotatedText": "текст",
        "color": "#00ff00",
        "colorCategory": "Green",
        "comment": "Это a comment",
        "date": "2023-10-23T20:33:35+03:00",
        "id": "highlight-p1x90y696",
        "page": 1,
        "pageLabel": "1",
        "type": "highlight",
        "x": 90.67,
        "y": 696.66
    }
]
```
This resolves the issue with unreadable characters in the comments.

P.S. This may not be crucial, but I'd like to mention that I'm using this project through your [Obsidian-Zotero-Integrator](https://github.com/mgmeyers/obsidian-zotero-integration). I should also note that I use Okular for annotation.



